### PR TITLE
Add Button component

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,16 @@
 <script>
+    import Button from './Button/index.svelte'
     import Icon from './Icon/index.svelte'
     import Text from './Text/index.svelte'
 </script>
+
+<style>
+    :root {
+        --button-gap: 8px;
+        --button-padding: 8px;
+        --button-size: 48px;
+    }
+</style>
 
 <ul>
     <li>
@@ -11,6 +20,71 @@
         <a href="#text">Text</a>
     </li>
 </ul>
+
+<section section="button">
+    <h2>Button</h2>
+
+    <p>Depends on the following CSS variables:</p>
+    <dl>
+        <dt>
+            <code>--button-gap</code>
+        </dt>
+        <dd>
+            Gap between the different components inside the button, if there are
+            multiple.
+        </dd>
+        <dt>
+            <code>--button-padding</code>
+        </dt>
+        <dd>
+            Space on both sides of the button's content when
+            <code>relaxed</code>
+            .
+        </dd>
+        <dt>
+            <code>--button-size</code>
+        </dt>
+        <dd>Minimum size of the button.</dd>
+    </dl>
+
+    <h3>Default</h3>
+    <div id="button-default">
+        <Button title="Example button" onclick={() => alert('Example!')}>
+            <Text>Example</Text>
+        </Button>
+    </div>
+
+    <h3>With icons</h3>
+
+    <div id="button-icon">
+        <Button title="Example button" onclick={() => alert('Example!')}>
+            <Icon type="sun" size={24} />
+        </Button>
+    </div>
+    <div id="button-icon-text">
+        <Button title="Example button" onclick={() => alert('Example!')}>
+            <Icon type="moon" size={24} />
+            <Text>Example</Text>
+        </Button>
+    </div>
+    <div id="button-text-icon">
+        <Button title="Example button" onclick={() => alert('Example!')}>
+            <Text>Example</Text>
+            <Icon type="sun" size={24} />
+        </Button>
+    </div>
+
+    <h3>Relaxed</h3>
+    <div id="button-relaxed">
+        <Button
+            title="Example button"
+            onclick={() => alert('Example!')}
+            relaxed>
+            <Icon type="moon" size={24} />
+            <Text>Example</Text>
+        </Button>
+    </div>
+</section>
 
 <section section="icon">
     <h2>Icon</h2>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,7 @@
 <script>
     import Button from './Button/index.svelte'
     import Icon from './Icon/index.svelte'
+    import Spacer from './Spacer/index.svelte'
     import Text from './Text/index.svelte'
 </script>
 
@@ -9,12 +10,19 @@
         --button-gap: 8px;
         --button-padding: 8px;
         --button-size: 48px;
+        --spacer-size: var(--button-gap);
     }
 </style>
 
 <ul>
     <li>
+        <a href="#button">Button</a>
+    </li>
+    <li>
         <a href="#icon">Icon</a>
+    </li>
+    <li>
+        <a href="#spacer">Spacer</a>
     </li>
     <li>
         <a href="#text">Text</a>
@@ -56,6 +64,19 @@
 
     <h3>With icons</h3>
 
+    <p>
+        <strong>Note:</strong>
+        Until the CSS property
+        <code>gap</code>
+        for Flexbox is
+        <a href="https://caniuse.com/#feat=flexbox-gap">better supported</a>
+        , buttons with multiple elements rely on
+        <a href="#spacer">
+            <code>Spacer</code>
+        </a>
+        to separate them.
+    </p>
+
     <div id="button-icon">
         <Button title="Example button" onclick={() => alert('Example!')}>
             <Icon type="sun" size={24} />
@@ -64,12 +85,14 @@
     <div id="button-icon-text">
         <Button title="Example button" onclick={() => alert('Example!')}>
             <Icon type="moon" size={24} />
+            <Spacer />
             <Text>Example</Text>
         </Button>
     </div>
     <div id="button-text-icon">
         <Button title="Example button" onclick={() => alert('Example!')}>
             <Text>Example</Text>
+            <Spacer />
             <Icon type="sun" size={24} />
         </Button>
     </div>
@@ -81,6 +104,7 @@
             onclick={() => alert('Example!')}
             relaxed>
             <Icon type="moon" size={24} />
+            <Spacer />
             <Text>Example</Text>
         </Button>
     </div>
@@ -117,6 +141,33 @@
     <h3>Custom size</h3>
     <div id="icon-small">
         <Icon type="moon" size={24} />
+    </div>
+</section>
+
+<section section="spacer">
+    <h2>Spacer</h2>
+
+    <p>
+        Allows to insert a space between other components when they are used in
+        another component `slot` and styling is not otherwise possible. Don't
+        over-use it!
+    </p>
+
+    <p>Depends on the following CSS variable:</p>
+    <dl>
+        <dt>
+            <code>--spacer-size</code>
+        </dt>
+        <dd>Width and height of the spacer.</dd>
+    </dl>
+
+    <h3>Default</h3>
+    <div id="spacer-default">
+        <Icon type="sun" />
+        <Icon type="sun" />
+        <Icon type="sun" />
+        <Spacer />
+        <Icon type="sun" />
     </div>
 </section>
 

--- a/src/Button/index.svelte
+++ b/src/Button/index.svelte
@@ -1,0 +1,27 @@
+<script>
+    export let relaxed = false
+    export let title
+    export let onclick = () => {}
+</script>
+
+<style>
+    button {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: var(--button-gap);
+        min-height: var(--button-size);
+        min-width: var(--button-size);
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+    }
+
+    .relaxed {
+        padding: var(--button-padding);
+    }
+</style>
+
+<button on:click={onclick} {title} type="button" class:relaxed>
+    <slot />
+</button>

--- a/src/Button/index.svelte
+++ b/src/Button/index.svelte
@@ -9,24 +9,14 @@
         display: flex;
         justify-content: center;
         align-items: center;
+        /* Can replace the Spacer when more widely supported.
+           See https://caniuse.com/#feat=flexbox-gap */
+        /* gap: var(--button-gap); */
         min-height: var(--button-size);
         min-width: var(--button-size);
         margin: 0;
         padding: 0;
         box-sizing: border-box;
-    }
-
-    /* Can be replaced by CSS gap when supported more widely. */
-    button > * {
-        margin: 0 calc(var(--button-gap) / 2);
-    }
-
-    button > *:first-child {
-        margin-left: 0;
-    }
-
-    button > *:last-child {
-        margin-right: 0;
     }
 
     .relaxed {

--- a/src/Button/index.svelte
+++ b/src/Button/index.svelte
@@ -9,12 +9,24 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        gap: var(--button-gap);
         min-height: var(--button-size);
         min-width: var(--button-size);
         margin: 0;
         padding: 0;
         box-sizing: border-box;
+    }
+
+    /* Can be replaced by CSS gap when supported more widely. */
+    button > * {
+        margin: 0 calc(var(--button-gap) / 2);
+    }
+
+    button > *:first-child {
+        margin-left: 0;
+    }
+
+    button > *:last-child {
+        margin-right: 0;
     }
 
     .relaxed {

--- a/src/Spacer/index.svelte
+++ b/src/Spacer/index.svelte
@@ -1,0 +1,9 @@
+<style>
+    div {
+        height: var(--spacer-size);
+        width: var(--spacer-size);
+        display: inline-block;
+    }
+</style>
+
+<div />

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,8 @@
  * @see {@link ../package.json}
  */
 
+import Button from './Button/index.svelte'
 import Icon from './Icon/index.svelte'
 import Text from './Text/index.svelte'
 
-export { Icon, Text }
+export { Button, Icon, Text }

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@
 
 import Button from './Button/index.svelte'
 import Icon from './Icon/index.svelte'
+import Spacer from './Spacer/index.svelte'
 import Text from './Text/index.svelte'
 
-export { Button, Icon, Text }
+export { Button, Icon, Spacer, Text }

--- a/test/Button.spec.js
+++ b/test/Button.spec.js
@@ -1,0 +1,27 @@
+describe('Button', () => {
+    it('is a button', async (browser) => {
+        await browser.url('http://localhost:5000/#/')
+        await browser.waitForElementVisible('#button-default')
+        browser.assert.elementPresent('#button-default button')
+    })
+
+    it('has a button type', async (browser) => {
+        await browser.url('http://localhost:5000/#/')
+        await browser.waitForElementVisible('#button-default')
+        browser.assert.attributeContains(
+            '#button-default button',
+            'type',
+            'button',
+        )
+    })
+
+    it('has a title', async (browser) => {
+        await browser.url('http://localhost:5000/#/')
+        await browser.waitForElementVisible('#button-default')
+        browser.assert.attributeContains(
+            '#button-default button',
+            'title',
+            'Example button',
+        )
+    })
+})


### PR DESCRIPTION
Supports theming via CSS variables.

A possible improvement would be to provide default values for those properties. I'll wait until having a few more components before settling on values.

**Considerations**

Adding a `Spacer` is a trade-off, but I think the convenience of the resulting API justifies not using [named slots](https://svelte.dev/tutorial/named-slots) for allowing the `Button` contents to be styled.

**References**

- https://caniuse.com/#feat=flexbox-gap