### PR TITLE
Fix Button relaxed spacing

### DIFF
--- a/src/Button/index.svelte
+++ b/src/Button/index.svelte
@@ -22,7 +22,7 @@
     }
 
     .relaxed {
-        padding: var(--button-padding);
+        padding: 0 var(--button-padding);
     }
 </style>
 


### PR DESCRIPTION
When buttons contain icons, the intention is not for them to grow vertically.